### PR TITLE
Add MariaDB healthcheck to prevent startup race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ This will start:
 docker ps
 ```
 
-You should see 4 containers running:
+You should see 4 containers running. MariaDB includes a healthcheck, so `jobmanager` will wait until the database is fully initialised before starting:
 
 ```
-CONTAINER ID   IMAGE                                         PORTS                     NAMES
-abc123...      apache_flink_and_docker_compose-jobmanager   0.0.0.0:8081->8081/tcp   jobmanager
-def456...      apache_flink_and_docker_compose-taskmanager  6123/tcp, 8081/tcp       taskmanager-1
-ghi789...      apache_flink_and_docker_compose-taskmanager  6123/tcp, 8081/tcp       taskmanager-2
-jkl012...      mariadb:11.8                                 0.0.0.0:3306->3306/tcp   mariadb
+CONTAINER ID   IMAGE                                         STATUS                  NAMES
+abc123...      apache_flink_and_docker_compose-jobmanager   Up 10 seconds           jobmanager
+def456...      apache_flink_and_docker_compose-taskmanager  Up 10 seconds           taskmanager-1
+ghi789...      apache_flink_and_docker_compose-taskmanager  Up 10 seconds           taskmanager-2
+jkl012...      mariadb:11.8                                 Up 20 seconds (healthy) mariadb
 ```
 
 ### 3. Run the CDC Pipeline

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
       - "3306:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   jobmanager:
     build: .
@@ -33,6 +39,9 @@ services:
         metrics.reporter.prom.port: 9091
     ports:
       - "8081:8081"
+    depends_on:
+      mariadb:
+        condition: service_healthy
     command: jobmanager
     volumes:
       - ./jobs/job.sql:/opt/flink/job.sql


### PR DESCRIPTION
## Summary

Fixes #3 — prevents a race condition where the Flink job could be submitted before MariaDB has finished initialising.

- Added a `healthcheck` to the MariaDB service using the built-in `healthcheck.sh` script with `--connect` and `--innodb_initialized` flags
- `jobmanager` now has `depends_on: mariadb: condition: service_healthy`, so it won't start until MariaDB is ready
- `start_period: 30s` gives MariaDB time to run `init.sql` before healthchecks count as failures

## What this fixes

A user following the Quick Start instructions (`docker compose up -d --build` then immediately submitting the job) could hit a connection error if MariaDB hadn't finished loading the schema and sample data. This was timing-dependent and harder to debug on slower machines.

## Tested

- Cold start with `docker compose up -d --build` — compose output shows `mariadb Waiting` → `mariadb Healthy` → `jobmanager Starting` (correct ordering)
- Submitted the Flink job immediately after startup — job succeeded first try
- Verified analytics output: `total_sales = 5500.00`